### PR TITLE
移除默认集群主机名配置

### DIFF
--- a/arex-chart/templates/arex-front-deployment.yaml
+++ b/arex-chart/templates/arex-front-deployment.yaml
@@ -35,13 +35,13 @@ spec:
           {{- end }}
           env:
             - name: SERVICE_REPORT_URL
-              value: http://{{ template "arex.report.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.report.service.servicePort }}  
+              value: http://{{ template "arex.report.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.report.service.servicePort }}  
             - name: SERVICE_SCHEDULE_URL
-              value: http://{{ template "arex.schedule.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.schedule.service.servicePort }}  
+              value: http://{{ template "arex.schedule.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.schedule.service.servicePort }}  
             - name: SERVICE_NODE_URL
-              value: http://{{ template "arex.node.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.node.service.servicePort }}  
+              value: http://{{ template "arex.node.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.node.service.servicePort }}  
             - name: SERVICE_STORAGE_URL
-              value: http://{{ template "arex.storage.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.storage.service.servicePort }}  
+              value: http://{{ template "arex.storage.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.storage.service.servicePort }}  
           ports:
             - containerPort: {{ .Values.front.service.servicePort }}
           resources:

--- a/arex-chart/templates/arex-report-deployment.yaml
+++ b/arex-chart/templates/arex-report-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: JAVA_OPTS
               value: -Darex.report.mongo.uri={{ include "arex.mongoConnection" .}}
                 -Darex.redis.uri={{ include "arex.redisConnection" .}}
-                -Darex.storage.service.url=http://{{ template "arex.storage.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.storage.service.servicePort }} 
+                -Darex.storage.service.url=http://{{ template "arex.storage.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.storage.service.servicePort }} 
                 -Darex.ui.url=http://{{ template "arex.front.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.front.service.servicePort }}
           ports:
             - containerPort: {{ .Values.report.service.servicePort }}

--- a/arex-chart/templates/arex-schedule-deployment.yaml
+++ b/arex-chart/templates/arex-schedule-deployment.yaml
@@ -37,8 +37,8 @@ spec:
             - name: JAVA_OPTS
               value: -Dmongo.uri={{ include "arex.mongoConnection" .}}
                 -Darex.schedule.cache.redis.host={{ include "arex.redisConnection" .}}
-                -Darex.storage.service.api=http://{{ template "arex.storage.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.storage.service.servicePort }} 
-                -Darex.report.service.api=http://{{ template "arex.report.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.report.service.servicePort }}
+                -Darex.storage.service.api=http://{{ template "arex.storage.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.storage.service.servicePort }} 
+                -Darex.report.service.api=http://{{ template "arex.report.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.report.service.servicePort }}
           ports:
             - containerPort: {{ .Values.schedule.service.servicePort }}
           resources:

--- a/arex-chart/templates/arex-storage-deployment.yaml
+++ b/arex-chart/templates/arex-storage-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - name: JAVA_OPTS
               value: -Darex.storage.mongo.host={{ include "arex.mongoConnection" .}}
                 -Darex.storage.cache.url={{ include "arex.redisConnection" .}}
-                -Darex.report.service.api=http://{{ template "arex.report.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.report.service.servicePort }}/
+                -Darex.report.service.api=http://{{ template "arex.report.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.report.service.servicePort }}/
           ports:
             - containerPort: {{ .Values.storage.service.servicePort }}
           resources:


### PR DESCRIPTION
服务环境变量使用默认集群主机名会出现集群不是默认cluster.local时出现无法使用