### PR TITLE
fix: rename report api to web api in docker-compose-2x.yml

### DIFF
--- a/docker-compose-2x.yml
+++ b/docker-compose-2x.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - ./arex-logs/arex-front:/usr/src/app/logs
     environment:
-      - SERVICE_REPORT_URL=http://arex-api-service:8080
+      - SERVICE_API_URL=http://arex-api-service:8080
       - SERVICE_SCHEDULE_URL=http://arex-schedule-service:8080
       - SERVICE_STORAGE_URL=http://arex-storage-service:8080
     depends_on:


### PR DESCRIPTION
环境变量应使用 SERVICE_API_URL，docker-compose-2x.yml 中未同步修改，导致服务报错。
修改前：
<img width="1344" alt="image" src="https://github.com/arextest/deployments/assets/30255624/21277ddb-6912-45a8-8760-cf30823b7fc8">

修改后：
<img width="639" alt="image" src="https://github.com/arextest/deployments/assets/30255624/ed16a4fd-3291-4ff9-883e-e62e513e95b7">
